### PR TITLE
License is BSD 3-Clause

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   script: python setup.py install
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -30,7 +30,7 @@ test:
 
 about:
   home: http://github.com/zapier/django-rest-hooks
-  license: BSD License
+  license: BSD 3-Clause
   summary: A powerful mechanism for sending real time API notifications via a new subscription model.
 
 extra:


### PR DESCRIPTION
Asked for clarification on the license with owners of source at https://github.com/zapier/django-rest-hooks/issues/30 as requested at https://github.com/conda-forge/staged-recipes/pull/823#discussion_r67681995. It's `BSD 3-Clause`.

Let's wait for everyone to agree at https://github.com/zapier/django-rest-hooks/issues/30 before we merge.
