### PR TITLE
leave-maintainers

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,6 +37,5 @@ about:
 
 extra:
   recipe-maintainers:
-    - Korijn
     - IvoFlipse
     - Maxyme


### PR DESCRIPTION
I no longer wish to maintain conda packages, so I'm editing myself out of the maintainers in the recipes.